### PR TITLE
Now the watcher can be stopped.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,7 @@
-(defproject clojure-watch "0.1.9"
+(defproject clojure-watch "0.1.10"
   :description "A library for watching file system events."
   :url "https://github.com/derekchiang/Clojure-Watch"
   :license {:name "WTFPL"
             :url "http://www.wtfpl.net/"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojure-contrib "LATEST"]])
+  :dependencies [[org.clojure/clojure "1.5.1"]])
 

--- a/src/clojure_watch/core.clj
+++ b/src/clojure_watch/core.clj
@@ -1,11 +1,9 @@
 (ns clojure-watch.core
-  (:require [clojure.contrib.import-static :as import-static])
   (:import (java.nio.file WatchService Paths FileSystems)))
 
-(import-static/import-static java.nio.file.StandardWatchEventKinds
-                             ENTRY_CREATE
-                             ENTRY_DELETE
-                             ENTRY_MODIFY)
+(def ENTRY_CREATE java.nio.file.StandardWatchEventKinds/ENTRY_CREATE)
+(def ENTRY_DELETE java.nio.file.StandardWatchEventKinds/ENTRY_DELETE)
+(def ENTRY_MODIFY java.nio.file.StandardWatchEventKinds/ENTRY_MODIFY)
 
 (defn register [{:keys [path event-types callback options] :as spec}
                 watcher keys]
@@ -74,5 +72,8 @@
                              ; Run callback in another thread
                              @(future (callback kind name))))
                          (.reset key)
-                         (recur watcher keys))))]
-        (watch watcher keys)))))
+                         (recur watcher keys))))
+              (close-watcher []
+                (.close watcher))]
+        (future (watch watcher keys))
+        close-watcher))))

--- a/src/clojure_watch/example.clj
+++ b/src/clojure_watch/example.clj
@@ -1,8 +1,18 @@
 (ns clojure-watch.example
   (:require [clojure-watch.core :refer [start-watch]]))
 
-(start-watch [{:path "/home/derek/Desktop"
-               :event-types [:create :modify :delete]
-               :bootstrap (fn [path] (println "Starting to watch " path))
-               :callback (fn [event filename] (println event filename))
-               :options {:recursive true}}])
+(defn monitor-dir
+  [path]
+  (println "monitoring directory: " path)
+  (start-watch [{:path path
+                 :event-types [:create :modify :delete]
+                 :bootstrap (fn [path] (println "Starting to watch " path))
+                 :callback (fn [event filename] (println event filename))
+                 :options {:recursive true}}]))
+
+; Set this to a valid directory path
+;(let [stop-watch (monitor-dir "/Users/rosejn/Desktop")]
+;  (Thread/sleep 20000) ; Manipulate files on the path
+;  (stop-watch)) ; turn off the watcher
+;
+


### PR DESCRIPTION
- start-watch runs watcher in a background thread and returns a function that
  can be called to stop the watcher
- removed requirement for clojure-contrib by not using import-static
- updated example
- incremented minor version number
