### PR TITLE
add HIGH SensitivityWatchEventModifier to register call

### DIFF
--- a/src/clojure_watch/core.clj
+++ b/src/clojure_watch/core.clj
@@ -21,7 +21,12 @@
                                    :modify (conj acc ENTRY_MODIFY)))
                                []
                                event-types)
-                 key (.register dir watcher (into-array types))]
+
+                 modifiers (doto (make-array java.nio.file.WatchEvent$Modifier 1)
+                             (aset 0 com.sun.nio.file.SensitivityWatchEventModifier/HIGH))
+
+                 key (.register dir watcher (into-array types) modifiers)]
+
              (assoc keys key [dir callback])))]
     (register-helper spec watcher keys)))
 

--- a/src/clojure_watch/core.clj
+++ b/src/clojure_watch/core.clj
@@ -25,7 +25,7 @@
                  modifier  (try
                              (let [c (Class/forName "com.sun.nio.file.SensitivityWatchEventModifier")
                                    f (.getField c "HIGH")]
-                               (.get c f))
+                               (.get f c))
                              (catch Exception e))
 
                  modifiers (when modifier

--- a/src/clojure_watch/core.clj
+++ b/src/clojure_watch/core.clj
@@ -22,10 +22,19 @@
                                []
                                event-types)
 
-                 modifiers (doto (make-array java.nio.file.WatchEvent$Modifier 1)
-                             (aset 0 com.sun.nio.file.SensitivityWatchEventModifier/HIGH))
+                 modifier  (try
+                             (let [c (Class/forName "com.sun.nio.file.SensitivityWatchEventModifier")
+                                   f (.getField c "HIGH")]
+                               (.get c f))
+                             (catch Exception e))
 
-                 key (.register dir watcher (into-array types) modifiers)]
+                 modifiers (when modifier
+                             (doto (make-array java.nio.file.WatchEvent$Modifier 1)
+                               (aset 0 modifier)))
+
+                 key (if modifiers
+                       (.register dir watcher (into-array types) modifiers)
+                       (.register dir watcher (into-array types)))]
 
              (assoc keys key [dir callback])))]
     (register-helper spec watcher keys)))


### PR DESCRIPTION
for improved performance on Mac OS/X

see:  https://github.com/HotswapProjects/HotswapAgent/issues/41
      http://stackoverflow.com/questions/9588737/is-java-7-watchservice-slow-for-anyone-else/11182515#11182515