### PR TITLE
- Don't block while running the callback

### DIFF
--- a/src/clojure_watch/core.clj
+++ b/src/clojure_watch/core.clj
@@ -84,8 +84,9 @@
                                            (.resolve dir)
                                            str)]
                              ; Run callback in another thread
-                             @(future (callback kind name))))
-                         (.reset key)
+                             (future (do 
+                               (callback kind name)
+                               (.reset key)))))
                          (recur watcher keys))))
               (close-watcher []
                 (.close watcher))]


### PR DESCRIPTION
While the current implementation spawns a separate thread to process the fired event, it blocks immediately (dereferences the future), so effectively it doesn't use the new thread. I've changed implementation a bit to be unblocking. I'm not sure if the (.reset key) **must** be performed after the callback is processed or not, but to be on the safe side and preserve the previous semantics I've placed it in the same thread as the callback. 